### PR TITLE
Add: Novo migration que altera a tabela alarmes novamente

### DIFF
--- a/database/migration/004_alterTable_alarmes.sql
+++ b/database/migration/004_alterTable_alarmes.sql
@@ -1,0 +1,6 @@
+use Meteorological_Data_Collector;
+
+ALTER TABLE Alarme 
+    MODIFY cod_alarme INT auto_increment
+
+    


### PR DESCRIPTION
Alterei o campo da tabela alarmes, na 004 migration.

sem ela, o sistema não adicionaria os ids automaticamente